### PR TITLE
Add support for tags with spaces

### DIFF
--- a/timew
+++ b/timew
@@ -6,14 +6,14 @@
 #
 function __get_commands()
 {
-  echo "annotate cancel config continue day delete diagnostics export extensions gaps get help join lengthen modify month move report shorten show split start stop summary tag tags track undo untag week"
+  echo "annotate cancel config continue day delete diagnostics export extensions gaps get help join lengthen modify month move report shorten show split start stop summary tag tags track undo untag week" | tr ' ' '\n'
 }
 
 function __get_subcommands()
 {
   case "${1}" in
     modify)
-      echo "end start"
+      echo -e "end\nstart"
       ;;
     *)
       echo ""
@@ -23,12 +23,12 @@ function __get_subcommands()
 
 function __get_help_items()
 {
-  echo "$( __get_commands ) interval hints date duration dom"
+  echo -e "$( __get_commands )\ninterval\nhints\ndate\nduration\ndom"
 }
 
 function __get_options()
 {
-  echo "--help --verbose --version"
+  echo -e "--help\n--verbose\n--version"
 }
 
 function __get_ids()
@@ -38,7 +38,7 @@ function __get_ids()
 
 function __get_tags()
 {
-  timew tags | awk '{if(NR>3)print $1}'
+  timew tags | tail -n +4 -- | sed -e "s/-$//" -e "s/[[:space:]]*$//"
 }
 
 function __get_extensions()
@@ -147,7 +147,7 @@ function _timew()
       ;;
   esac
 
-  COMPREPLY=($( compgen -W "${wordlist}" -- "${cur}" ))
+  IFS=$'\n' COMPREPLY=($( compgen -W "${wordlist}" -- "${cur}" ))
 }
 
 complete -F _timew timew


### PR DESCRIPTION
Now autocompletion will not split tags with spaces.

For example, we have two tags "Reading" and "Three Body Problem"

Old behavior:
```
$ timew start <tab>
Body
Problem
Reading
Three
```

New behavior:
```
$ timew start <tab>
Reading
Three Body Problem
```

`\n`'s in code is a bit ugly, but we need to use it as a separator, to leave spaces alone.