### PR TITLE
Remove useless shebang

### DIFF
--- a/timew
+++ b/timew
@@ -1,12 +1,10 @@
-#!/usr/bin/env bash
-#
 # Bash completion for TimeWarrior
 #
 # Copyright (C) 2017 - 2019  Thomas Lauf
 #
 function __get_commands()
 {
-  echo "annotate cancel config continue day delete diagnostics export extensions gaps get help join lengthen modify month move report shorten show split start stop summary tag tags track undo untag week"
+  echo "annotate cancel config continue day delete diagnostics export extensions gaps get help join lengthen modify month move report resize shorten show split start stop summary tag tags track undo untag week"
 }
 
 function __get_subcommands()
@@ -109,7 +107,7 @@ function _timew()
     cancel|config|diagnostics|day|extensions|get|month|show|undo|week)
       wordlist=""
       ;;
-    annotate|continue|delete|join|lengthen|move|shorten|split)
+    annotate|continue|delete|join|lengthen|move|resize|shorten|split)
       wordlist=$( __get_ids )
       ;;
     export|gaps|start|stop|summary|tags|track)


### PR DESCRIPTION
Completion scripts are sourced, not executed.
There shouldn't be a shebang and they shouldn't be executable.
This will avoid an Lintian error when packaging for Debian.