### PR TITLE
Enhanced workaround for #8 (tag description)

### DIFF
--- a/timew
+++ b/timew
@@ -42,7 +42,7 @@ function __get_ids()
 
 function __get_tags()
 {
-  timew tags | tail -n +4 -- | sed -e "s|[[:space:]]\+-.*||"
+  timew tags | tail -n +4 -- | sed -e "s|\(.*\)[[:space:]]\+-.*|\1|"
 }
 
 function __get_extensions()

--- a/timew
+++ b/timew
@@ -42,7 +42,7 @@ function __get_ids()
 
 function __get_tags()
 {
-  timew tags | tail -n +4 -- | sed -e "s|\(.*\)[[:space:]]\+-.*|\1|"
+  timew tags | tail -n +4 -- | sed -E "s;(.*)[[:space:]]+-($|%.*);\1;"
 }
 
 function __get_extensions()

--- a/timew
+++ b/timew
@@ -42,7 +42,7 @@ function __get_ids()
 
 function __get_tags()
 {
-  timew tags | tail -n +4 -- | sed -e "s|[[:space:]]*-.*||"
+  timew tags | tail -n +4 -- | sed -e "s|[[:space:]]\+-.*||"
 }
 
 function __get_extensions()


### PR DESCRIPTION
Tentative better workaround for #8.

You need to prefix every description with `-%`. After a few iterations (see the commits), I think this should work in most cases, if one remembers to prefix their descriptions, ` -%` being very unlikely to show up in a tag name or a description content.