### PR TITLE
Fix tag completion

### DIFF
--- a/timew
+++ b/timew
@@ -42,7 +42,19 @@ function __get_ids()
 
 function __get_tags()
 {
-  timew get dom.tracked.tags "${TIMEW_COMPLETION_TAGS_RANGE:-":all"}"
+  tags=$(timew get dom.tracked.tags "${TIMEW_COMPLETION_TAGS_RANGE:-":all"}")
+  # return each tag on its own line
+  while [[ "${tags}" ]]; do
+    if [[ "${tags}" =~ ^\"[^\"]*\" ]]; then
+      tag="${BASH_REMATCH[0]:1:-1}"
+      tags="${tags#\"${tag}\"}"
+    else
+      tag="${tags%% *}"
+      tags="${tags#$tag}"
+    fi
+    echo "${tag}"
+    tags="${tags# }"
+  done
 }
 
 function __get_extensions()


### PR DESCRIPTION
To fix the issue described in https://github.com/GothenburgBitFactory/timewarrior/issues/581 I adapted the __get_tags() function. This also works with tags containing spaces.